### PR TITLE
Fix: Correct plugin installation instructions in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,20 +33,20 @@ A comprehensive plugin for spec-driven development with React, Node.js, and Type
 
 ### Using Claude CLI
 
-Install the SDD plugin directly from the marketplace:
+Add the marketplace and install the SDD plugin:
 
 ```bash
-claude-code plugin install https://github.com/LiorCohen/claude-code-plugins
+claude plugin marketplace add https://github.com/LiorCohen/claude-code-plugins
+claude plugin install sdd
 ```
-
-This will automatically discover and load the SDD plugin.
 
 ### Inside Claude Code
 
-You can also install plugins using the `/plugin` command:
+You can also use the `/plugin` command:
 
 ```
-/plugin install https://github.com/LiorCohen/claude-code-plugins
+/plugin marketplace add https://github.com/LiorCohen/claude-code-plugins
+/plugin install sdd
 ```
 
 Once installed, all commands, agents, and skills will be available immediately.

--- a/full-stack-spec-driven-dev/README.md
+++ b/full-stack-spec-driven-dev/README.md
@@ -94,19 +94,21 @@ Project lifecycle automation:
 
 ### Installation
 
-Install the plugin using the Claude CLI:
+Add the marketplace and install the SDD plugin using the Claude CLI:
 
 ```bash
-claude-code plugin install https://github.com/LiorCohen/claude-code-plugins
+claude plugin marketplace add https://github.com/LiorCohen/claude-code-plugins
+claude plugin install sdd
 ```
 
 Or inside Claude Code:
 
 ```
-/plugin install https://github.com/LiorCohen/claude-code-plugins
+/plugin marketplace add https://github.com/LiorCohen/claude-code-plugins
+/plugin install sdd
 ```
 
-The plugin will be automatically loaded and all commands will be available.
+Once installed, all commands, agents, and skills will be available immediately.
 
 ### Usage
 


### PR DESCRIPTION
## Summary
- Fixed incorrect installation commands in both `README.md` and `full-stack-spec-driven-dev/README.md`
- Updated to use correct two-step process: `claude plugin marketplace add` + `claude plugin install sdd`
- Fixed both CLI and in-Claude `/plugin` command examples

## Test plan
- [x] Verify installation instructions match actual CLI behavior
- [x] Confirm formatting renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)